### PR TITLE
Add terraform plan wrapper for cost estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ terraform plan -out=tfplan
 terraform show -json tfplan > plan.json
 ```
 
+If you want to run cost estimation automatically, a convenience script
+`terraform_plan_with_cost.sh` is provided. Use it in place of the Terraform
+binary or alias it as `terraform`. Pass any usual `plan` arguments after the
+command:
+
+```bash
+./terraform_plan_with_cost.sh plan
+```
+This wrapper executes `terraform plan`, converts the plan to JSON, runs the cost
+calculator and prints the report.
+
 ### Running the Calculator
 
 You can run the helper script or the module entry point.

--- a/terraform_plan_with_cost.sh
+++ b/terraform_plan_with_cost.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Wrapper script to run terraform plan and cost estimation in one step
+
+set -euo pipefail
+
+TF_BIN=${TF_BIN:-terraform}
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 plan [additional terraform args]" >&2
+    exit 1
+fi
+
+if [ "$1" = "plan" ]; then
+    shift
+    PLAN_OUT=$(mktemp tfplan-XXXX.out)
+    PLAN_JSON=$(mktemp plan-XXXX.json)
+
+    "$TF_BIN" plan "$@" -out="$PLAN_OUT"
+    "$TF_BIN" show -json "$PLAN_OUT" > "$PLAN_JSON"
+
+    # Run cost estimation using the helper script
+    python calculate_cost.py "$PLAN_JSON"
+
+    # Clean up temporary files
+    rm -f "$PLAN_OUT" "$PLAN_JSON"
+else
+    "$TF_BIN" "$@"
+fi


### PR DESCRIPTION
## Summary
- add `terraform_plan_with_cost.sh` wrapper script to run Terraform plan and cost calculator in a single step
- document wrapper usage in README

## Testing
- `make test` *(fails: No module named pytest)*