### PR TITLE
Add terraform.sh wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ terraform plan -out=tfplan
 terraform show -json tfplan > plan.json
 ```
 
+If you want to run cost estimation automatically, a convenience script
+`terraform.sh` is provided. Use it in place of the Terraform binary or alias it
+as `terraform`. Pass any usual `plan` arguments after the command:
+
+```bash
+./terraform.sh plan
+```
+This wrapper executes `terraform plan`, converts the plan to JSON, runs the cost
+calculator and prints the report.
+
 ### Running the Calculator
 
 You can run the helper script or the module entry point.

--- a/terraform.sh
+++ b/terraform.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Wrapper script to run "terraform plan" and cost estimation in one step
+# Usage: ./terraform.sh plan [args]
+
+set -euo pipefail
+
+TF_BIN=${TF_BIN:-terraform}
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 plan [additional terraform args]" >&2
+    exit 1
+fi
+
+if [ "$1" = "plan" ]; then
+    shift
+    PLAN_OUT=$(mktemp tfplan-XXXX.out)
+    PLAN_JSON=$(mktemp plan-XXXX.json)
+    trap 'rm -f "$PLAN_OUT" "$PLAN_JSON"' EXIT
+
+    "$TF_BIN" plan "$@" -out="$PLAN_OUT"
+    "$TF_BIN" show -json "$PLAN_OUT" > "$PLAN_JSON"
+
+    # Run cost estimation using the helper script
+    python calculate_cost.py "$PLAN_JSON"
+
+    # Clean up handled by trap
+else
+    "$TF_BIN" "$@"
+fi


### PR DESCRIPTION
## Summary
- rename cost estimation wrapper script to `terraform.sh`
- update README instructions for new `terraform.sh` usage
- keep cleanup of temporary files via `trap`

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement requests)*
- `make test` *(fails: No module named pytest)*
- `make lint` *(fails: No module named flake8)*