### PR TITLE
Add terrafin CLI for simplified cost estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ terraform plan -out=tfplan
 terraform show -json tfplan > plan.json
 ```
 
+If you want to run cost estimation automatically without chaining multiple
+commands, use the `terrafin` wrapper included in this repository. It behaves
+just like the Terraform CLI, so you can run `terrafin init`, `terrafin plan` or
+any other subcommand. When you run `terrafin plan`, the plan is captured,
+converted to JSON and fed to the cost calculator automatically:
+
+```bash
+./terrafin plan
+```
+This wrapper executes `terraform plan`, converts the output to JSON, runs the
+cost calculator and prints the report. Other commands are passed directly to the
+Terraform binary.
+
 ### Running the Calculator
 
 You can run the helper script or the module entry point.

--- a/terrafin
+++ b/terrafin
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Terrafin CLI wrapper for Terraform with integrated cost estimation
+
+set -euo pipefail
+
+TF_BIN=${TF_BIN:-terraform}
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <command> [args]" >&2
+    exit 1
+fi
+
+cmd="$1"
+shift
+
+case "$cmd" in
+    plan)
+        PLAN_OUT=$(mktemp tfplan-XXXX.out)
+        PLAN_JSON=$(mktemp plan-XXXX.json)
+
+        "$TF_BIN" plan "$@" -out="$PLAN_OUT"
+        "$TF_BIN" show -json "$PLAN_OUT" > "$PLAN_JSON"
+
+        python calculate_cost.py "$PLAN_JSON"
+
+        rm -f "$PLAN_OUT" "$PLAN_JSON"
+        ;;
+    *)
+        "$TF_BIN" "$cmd" "$@"
+        ;;
+esac


### PR DESCRIPTION
## Summary
- replace old wrapper with new `terrafin` CLI
- run cost calculation automatically when executing `terrafin plan`
- document usage of `terrafin` in the README

## Testing
- `make test` *(fails: No module named pytest)*